### PR TITLE
Deprecated runwayml huggingface repo pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ PyTorch implementation of Stable Diffusion from scratch
 
 ## Download weights and tokenizer files:
 
-1. Download `vocab.json` and `merges.txt` from https://huggingface.co/runwayml/stable-diffusion-v1-5/tree/main/tokenizer and save them in the `data` folder
-2. Download `v1-5-pruned-emaonly.ckpt` from https://huggingface.co/runwayml/stable-diffusion-v1-5/tree/main and save it in the `data` folder
+1. Download `vocab.json` and `merges.txt` from https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5/tree/main/tokenizer and save them in the `data` folder
+2. Download `v1-5-pruned-emaonly.ckpt` from https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5/tree/main and save it in the `data` folder
 
 ## Tested fine-tuned models:
 


### PR DESCRIPTION
Hi, thanks for the tutorial! It was super fun following along - just wanted to leave a note here that the runwayml org has been deprecated on huggingface and thus the link to the model weights is no longer there - I have fixed this by replacing it with one from the stable diffusion org, which is the mirror of the old repo

